### PR TITLE
DEV: Move settings description to locales/en.yml

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,3 +1,5 @@
 en:
   theme_metadata:
     description: "TODO"
+    settings:
+      example_setting: "A description of a setting."

--- a/settings.yml
+++ b/settings.yml
@@ -1,4 +1,2 @@
 example_setting:
   default: true
-  description:
-    en: A description of a setting.


### PR DESCRIPTION
Since all theme components are [gradually](https://meta.discourse.org/t/make-the-settings-descriptions-of-all-official-theme-components-translatable/311803/2) being migrated to this structure, I think it makes sense to adapt the template as well.