### PR TITLE
DEV: Remove the discourse-compatibility entry

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,2 +1,0 @@
-< 3.5.0.beta5-dev: 5e7bbafe0210010c61f337762a3d278ee9b75e8a
-


### PR DESCRIPTION
Accidentally added in 742f79cbc1e5af8ffdc3dc6b5cad37c829adf76d