### PR TITLE
DEV: Remove the discourse-compatibility entry

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,2 +1,8 @@
-< 3.6.0.beta1-dev: 38c281a9907b82f8af2a3a63e53801653fb3097c
-
+# Map Discourse core versions to a specific commit of this theme.
+# More info: https://meta.discourse.org/t/how-to-use-discourse-compatibility-files/260786
+#
+# Format:
+# < core-version: commit-hash of this theme
+#
+# Example:
+# < 3.2.0.beta2-dev: abcde12345


### PR DESCRIPTION
The entry was added in https://github.com/discourse/discourse-theme-skeleton/commit/9d0a95737b49a0574445a6f59c5b237c139c6474

I removed it and added a comment to explain usage of the file.