### PR TITLE
FIX: d-compat workflow for repos with read-only default permissions

### DIFF
--- a/.github/workflows/d-compat-branch.yml
+++ b/.github/workflows/d-compat-branch.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: write
+
 jobs:
   ci:
     uses: discourse/.github/.github/workflows/create-d-compat-branch.yml@v1


### PR DESCRIPTION
`create-d-compat-branch.yml` requires `contents: write`, but reusable workflows cannot elevate permissions—the caller must grant them explicitly. This fails when default workflow permissions are read-only, which is a common default (e.g. for personal repositories). https://docs.github.com/en/actions/using-workflows/reusing-workflows

<img width="1085" height="269" alt="image" src="https://github.com/user-attachments/assets/40856691-1cf0-4dc6-848c-7d5492614ab7" />
